### PR TITLE
Some profiler-based performance optimisations

### DIFF
--- a/Assets/Scripts/PlayerRayMarchCollider.cs
+++ b/Assets/Scripts/PlayerRayMarchCollider.cs
@@ -39,14 +39,16 @@ namespace Unity.Mathematics
         public float GetShapeDistance(Shape4D shape, float4 p4D)
         {
             p4D -= (float4) shape.Position();
-           
-            p4D.xz = mul(p4D.xz, float2x2(cos(shape.Rotation().y), sin(shape.Rotation().y), -sin(shape.Rotation().y), cos(shape.Rotation().y)));
-            p4D.yz = mul(p4D.yz, float2x2(cos(shape.Rotation().x), -sin(shape.Rotation().x), sin(shape.Rotation().x), cos(shape.Rotation().x)));
-            p4D.xy = mul(p4D.xy, float2x2(cos(shape.Rotation().z), -sin(shape.Rotation().z), sin(shape.Rotation().z), cos(shape.Rotation().z)));
 
-            p4D.xw = mul(p4D.xw, float2x2(cos(shape.RotationW().x), sin(shape.RotationW().x), -sin(shape.RotationW().x), cos(shape.RotationW().x)));
-            p4D.zw = mul(p4D.zw, float2x2(cos(shape.RotationW().z), -sin(shape.RotationW().z), sin(shape.RotationW().z), cos(shape.RotationW().z)));
-            p4D.yw = mul(p4D.yw, float2x2(cos(shape.RotationW().y), -sin(shape.RotationW().y), sin(shape.RotationW().y), cos(shape.RotationW().y)));
+            Vector3 shapeRotation = shape.Rotation();
+            p4D.xz = mul(p4D.xz, math.float2x2(cos(shapeRotation.y), sin(shapeRotation.y), -sin(shapeRotation.y), cos(shapeRotation.y)));
+            p4D.yz = mul(p4D.yz, math.float2x2(cos(shapeRotation.x), -sin(shapeRotation.x), sin(shapeRotation.x), cos(shapeRotation.x)));
+            p4D.xy = mul(p4D.xy, math.float2x2(cos(shapeRotation.z), -sin(shapeRotation.z), sin(shapeRotation.z), cos(shapeRotation.z)));
+
+            Vector3 shapeRotationW = shape.RotationW();
+            p4D.xw = mul(p4D.xw, math.float2x2(cos(shapeRotationW.x), sin(shapeRotationW.x), -sin(shapeRotationW.x), cos(shapeRotationW.x)));
+            p4D.zw = mul(p4D.zw, math.float2x2(cos(shapeRotationW.z), -sin(shapeRotationW.z), sin(shapeRotationW.z), cos(shapeRotationW.z)));
+            p4D.yw = mul(p4D.yw, math.float2x2(cos(shapeRotationW.y), -sin(shapeRotationW.y), sin(shapeRotationW.y), cos(shapeRotationW.y)));
 
 
 

--- a/Assets/Scripts/RaymarchCam.cs
+++ b/Assets/Scripts/RaymarchCam.cs
@@ -201,7 +201,7 @@ public class RaymarchCam : SceneViewFilter
 
     void CreateScene()
     {
-        List<Shape4D> allShapes = new List<Shape4D>(FindObjectsOfType<Shape4D>());
+        List<Shape4D> allShapes = new List<Shape4D>(FindObjectsOfType<Shape4D>());//todo: do not use FindObjectsOfType()
         allShapes.Sort((a, b) => a.operation.CompareTo(b.operation));
 
         orderedShapes = new List<Shape4D>();
@@ -218,9 +218,9 @@ public class RaymarchCam : SceneViewFilter
                 // Add all children of the shape (nested children not supported currently)
                 for (int j = 0; j < parentShape.childCount; j++)
                 {
-                    if (parentShape.GetChild(j).GetComponent<Shape4D>() != null)
+                    if (parentShape.GetChild(j).TryGetComponent(out Shape4D shape4D))
                     {
-                        orderedShapes.Add(parentShape.GetChild(j).GetComponent<Shape4D>());
+                        orderedShapes.Add(shape4D);
                         orderedShapes[orderedShapes.Count - 1].numChildren = 0;
                     }
                 }

--- a/Assets/Scripts/Shape4D.cs
+++ b/Assets/Scripts/Shape4D.cs
@@ -49,9 +49,9 @@ public class Shape4D : MonoBehaviour
     //returns the 4D scale of the object
     public Vector4 Scale()
     {
-        if (transform.parent != null && transform.parent.GetComponent<Shape4D>() != null)
+        if (transform.parent != null && transform.parent.TryGetComponent(out Shape4D shape))
         {
-            parentScale = transform.parent.GetComponent<Shape4D>().Scale();
+            parentScale = shape.Scale();
         }
         else parentScale = Vector4.one;
 

--- a/Assets/Scripts/Shape4D.cs
+++ b/Assets/Scripts/Shape4D.cs
@@ -32,7 +32,8 @@ public class Shape4D : MonoBehaviour
     // returns the 4D position of the object
     public Vector4 Position()
     {
-        return new Vector4(transform.position.x, transform.position.y, transform.position.z, positionW);
+        Vector3 position3D = transform.position;
+        return new Vector4(position3D.x, position3D.y, position3D.z, positionW);
     }
 
     //returns the 3D rotation of the object
@@ -55,7 +56,8 @@ public class Shape4D : MonoBehaviour
         }
         else parentScale = Vector4.one;
 
-        return Vector4.Scale(new Vector4(transform.localScale.x, transform.localScale.y, transform.localScale.z, scaleW), parentScale);
+        Vector3 localScale3D = transform.localScale;
+        return Vector4.Scale(new Vector4(localScale3D.x, localScale3D.y, localScale3D.z, scaleW), parentScale);
 
     }
 


### PR DESCRIPTION
PlayerRayMarchCollider.GetShapeDistance now is faster.
There are some easy-to-solve problems (using static List<Shape4D> instead of slow and memory allocating FindObjectsOfType<>). 
But GetShapeDistance is still too slow to be used with at least hundreds of objects. 